### PR TITLE
[WIP] Update bird2 and fastd documentation

### DIFF
--- a/docs/routing/bird/bird_babel.md
+++ b/docs/routing/bird/bird_babel.md
@@ -1,7 +1,7 @@
 Bird Babel configuration
 ========================
 
-In a file named `babel.conf` place the following template:
+In `/etc/bird/crxn/babel.conf` place the following template:
 
 ```
 # CRXN Babel protocol
@@ -13,8 +13,8 @@ protocol babel crxnBabel
 
     ipv6
     {
-        import filter crxn6;
-        export filter crxn6;
+        import filter crxnFilter;
+        export filter crxnFilter;
         table crxn;
     };
 }
@@ -22,7 +22,7 @@ protocol babel crxnBabel
 
 1. Set the `interface` list to a list of interfaces you wish the babel
 protocol to run on
-	* It also supports regex in a string so you can do `"interface*"` for example
+    * It also supports regex in a string so you can do `"interface*"` for example
 
 **Note:** For Bird 1.6 you will want to remove the `ipv6 {};`.
 

--- a/docs/routing/bird/bird_basics.md
+++ b/docs/routing/bird/bird_basics.md
@@ -5,7 +5,7 @@ Basics
 
 Installation of bird is relatively simple, your distro should have a `bird` package.
 
-Versions 1.6 and 2.0 will both work, there are slight differences in the configuratio
+Versions 1.6 and 2.0 will both work, there are slight differences in the configuration
 however but those will be shown in the configuration section that follows.
 
 ## Enabling forwarding
@@ -36,7 +36,6 @@ TODO: Weird experience with me, only doing `all` made it work
 
 ## Assigning the /64
 
-Normally people will assign the a `/64` out of their `/48`. Assign this to the interface of the LAN you want your router on.
+Normally people will assign a `/64` out of their `/48`. Assign this to the interface of the LAN you want your router on.
 
-A good IP choice for the router would be either `xxxx::1` or `xxxx::` so people can easily guess what to ping to test reachability
-to your network.
+A good IP choice for the router would be either `xxxx::1` or `xxxx::` so people can easily guess what to ping to test reachability to your network.


### PR DESCRIPTION
You probably don't want all the changes I've done such as changing file locations.

Bird2:
- Update filter to use primitive operator `~`
- Move the includes for protocol configuration into `bird.conf` (remove `protocols.conf`)
- Restrict direct route snooping to `eth*`

Fastd:
- Changed mode from `tap` to `multiap` (each peer on their own interface which is useful for route debugging)
- Change recommended location of fastd config to `/etc/fastd/crxn` (helps with systemd unit)
- Added instructions for using fastd systemd unit
